### PR TITLE
Add 'extendFile' option similar to 'template' option in HTMLWebpackPlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ new WriteJsonPlugin({
     path: 'public',
     // default output is timestamp.json
     filename: 'timestamp.json',
+    // [optional] merge (and overwrite) keys from given JSON file with given `object`
+    extendFile: path.join(__dirname, 'manifest.json'),
     pretty: true // makes file human-readable (default false)
 })
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,24 @@
 const path = require("path");
+const fs = require("fs");
 
 class WriteJsonWebpackPlugin {
   constructor(options) {
+    if (
+      "extendFile" in options &&
+      (typeof options.extendFile !== "string" ||
+        !path.isAbsolute(options.extendFile) ||
+        path.extname(options.extendFile) !== ".json")
+    ) {
+      throw new TypeError(
+        "`options.extendFile` must be an absolute path to a JSON file"
+      );
+    }
     this.options = options || {};
     this.options.object = options.object || {};
     this.options.path = options.path || "";
     this.options.filename = options.filename || "timestamp.json";
     this.options.pretty = options.pretty;
-
+    this.options.extendFile = options.extendFile;
     this.createObj = this.createObj.bind(this);
   }
 
@@ -21,11 +32,31 @@ class WriteJsonWebpackPlugin {
   }
 
   createObj(compilation, callback) {
-    const json = JSON.stringify(
-      this.options.object,
-      null,
-      this.options.pretty ? 2 : null
-    );
+    let obj = this.options.object;
+
+    if (this.options.extendFile) {
+      if (Array.isArray(compilation.fileDependencies)) {
+        if (
+          compilation.fileDependencies.indexOf(this.options.extendFile) === -1
+        ) {
+          compilation.fileDependencies.push(this.options.extendFile);
+        }
+      } else if (!compilation.fileDependencies.has(this.options.extendFile)) {
+        compilation.fileDependencies.add(this.options.extendFile);
+      }
+
+      try {
+        obj = Object.assign(
+          JSON.parse(fs.readFileSync(this.options.extendFile, "utf8")),
+          this.options.object
+        );
+      } catch (err) {
+        compilation.errors.push(err);
+        return callback();
+      }
+    }
+
+    const json = JSON.stringify(obj, null, this.options.pretty ? 2 : null);
     const output = path.join(this.options.path, this.options.filename);
 
     Object.assign(compilation.assets, {
@@ -39,7 +70,7 @@ class WriteJsonWebpackPlugin {
       },
     });
 
-    callback();
+    return callback();
   }
 }
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -257,7 +257,7 @@ const FAKE_DATA = require("../fixtures/fake_data.json");
         ).rejects.toThrow(TypeError);
       });
 
-      it("extends the data from JSON file with given object", async () => {
+      it("extends the data from JSON file with given object (overwrites keys with same name)", async () => {
         const tplData = {
           version: "1.0.2",
           someKey: "value",
@@ -282,13 +282,15 @@ const FAKE_DATA = require("../fixtures/fake_data.json");
           })
         ).resolves.toEqual(expect.anything());
 
-        expect(
-          JSON.parse(
-            fs.readFileSync(path.join(outputDir.name, "my_data.json"), {
-              encoding: "utf8",
-            })
-          )
-        ).toEqual(Object.assign({}, tplData, data));
+        const final = JSON.parse(
+          fs.readFileSync(path.join(outputDir.name, "my_data.json"), {
+            encoding: "utf8",
+          })
+        );
+        // merges data template JSON with given object
+        expect(final).toEqual(Object.assign({}, tplData, data));
+        // also overwrites keys from template with same name with given object
+        expect(final.someKey).toEqual(data.someKey);
       });
     });
   });

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -27,7 +27,9 @@ const FAKE_DATA = require("../fixtures/fake_data.json");
   {
     title: `Testing with webpack@${WEBPACK4_VERSION}`,
     webpack: webpack4,
-    specificWebpackConfig: { mode: "none" },
+    specificWebpackConfig: {
+      mode: "none",
+    },
   },
 ].forEach(({ title, webpack, specificWebpackConfig }) => {
   let outputDir;
@@ -63,7 +65,9 @@ const FAKE_DATA = require("../fixtures/fake_data.json");
 
   describe(title, () => {
     beforeEach(() => {
-      outputDir = tmp.dirSync({ unsafeCleanup: true });
+      outputDir = tmp.dirSync({
+        unsafeCleanup: true,
+      });
     });
 
     afterEach(done => {
@@ -232,6 +236,59 @@ const FAKE_DATA = require("../fixtures/fake_data.json");
             encoding: "utf8",
           })
         );
+      });
+    });
+
+    describe("extendFile option", () => {
+      it("throws when extendFile is not an absolute path to a JSON file", async () => {
+        await expect(
+          compile({
+            object: FAKE_DATA,
+            filename: "my_data.json",
+            extendFile: {},
+          })
+        ).rejects.toThrow(TypeError);
+        await expect(
+          compile({
+            object: FAKE_DATA,
+            filename: "my_data.json",
+            extendFile: "test.css",
+          })
+        ).rejects.toThrow(TypeError);
+      });
+
+      it("extends the data from JSON file with given object", async () => {
+        const tplData = {
+          version: "1.0.2",
+          someKey: "value",
+        };
+
+        const data = {
+          name: "mark",
+          someKey: 12,
+        };
+
+        const jsonTplFile = tmp.fileSync({
+          postfix: ".json",
+        });
+
+        fs.writeFileSync(jsonTplFile.name, JSON.stringify(tplData));
+
+        await expect(
+          compile({
+            object: data,
+            filename: "my_data.json",
+            extendFile: jsonTplFile.name,
+          })
+        ).resolves.toEqual(expect.anything());
+
+        expect(
+          JSON.parse(
+            fs.readFileSync(path.join(outputDir.name, "my_data.json"), {
+              encoding: "utf8",
+            })
+          )
+        ).toEqual(Object.assign({}, tplData, data));
       });
     });
   });


### PR DESCRIPTION
### Use case:

Browser extensions require a `manifest.json` file that describes the extension. In my case they are different in `development` and `production`.

This option lets me have a base `manifest.json` in my source directory and then override in my `webpack.config.json` as deemed fit.

Also, in watch mode, if the `manifest.json` is changed, the change is reflected to the final emitted `json` file.